### PR TITLE
Fix store to misaligned address

### DIFF
--- a/src/spice.c
+++ b/src/spice.c
@@ -944,7 +944,7 @@ void spice_disconnect_channel(struct SpiceChannel * channel)
 SPICE_STATUS spice_agent_connect()
 {
   uint32_t * packet = SPICE_PACKET(SPICE_MSGC_MAIN_AGENT_START, uint32_t, 0);
-  *packet = SPICE_AGENT_TOKENS_MAX;
+  memcpy(packet, &(uint32_t){SPICE_AGENT_TOKENS_MAX}, sizeof(uint32_t));
   if (!SPICE_SEND_PACKET(&spice.scMain, packet))
     return SPICE_STATUS_ERROR;
 


### PR DESCRIPTION
This resolves the following UBSan report:

```
/code/LookingGlass/repos/PureSpice/src/spice.c:947:11: runtime error: store to misaligned address 0x7ffed0d6dd8e for type 'uint32_t', which requires 4 byte alignment
0x7ffed0d6dd8e: note: pointer points here
 04 00 00 00 00 80  00 00 00 00 00 00 00 00  91 05 d7 ac 71 55 00 00  18 df d6 d0 fe 7f 00 00  20 00
```

GCC should generate ~equivalent code here, since memcpy is an intrinsic:
https://gcc.godbolt.org/z/YEYvdj

This original behavior was fine as-is on x86, but would've been not-unlikely to fault on ARM.