### PR TITLE
Store read return value in ssize_t instead of size_t

### DIFF
--- a/src/spice.c
+++ b/src/spice.c
@@ -1268,7 +1268,7 @@ SPICE_STATUS spice_discard_nl(struct SpiceChannel * channel, ssize_t size, int *
   ssize_t left = size;
   while(left)
   {
-    size_t len = read(channel->socket, c, left > sizeof(c) ? sizeof(c) : left);
+    ssize_t len = read(channel->socket, c, left > sizeof(c) ? sizeof(c) : left);
     if (len == 0)
       return SPICE_STATUS_NODATA;
 


### PR DESCRIPTION
Read can return negative values to signal error. Storing it in size_t len
means that the subsequent comparsion len < 0 is always false.

Using ssize_t will allow the comparsion to work.