### PR TITLE
channels: implement the cursor channel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(purespice STATIC
 	src/channel_playback.c
 	src/channel_record.c
 	src/channel_display.c
+	src/channel_cursor.c
 	src/agent.c
 )
 

--- a/include/purespice.h
+++ b/include/purespice.h
@@ -66,6 +66,7 @@ typedef enum PSChannelType
   PS_CHANNEL_PLAYBACK,
   PS_CHANNEL_RECORD,
   PS_CHANNEL_DISPLAY,
+  PS_CHANNEL_CURSOR,
 
   PS_CHANNEL_MAX
 }
@@ -247,6 +248,16 @@ typedef struct PSConfig
         uint32_t color);
   }
   display;
+
+  struct
+  {
+    /* enable the cursor channel if available */
+    bool enable;
+
+    /* automatically connect to the channel as soon as it's available */
+    bool autoConnect;
+  }
+  cursor;
 }
 PSConfig;
 

--- a/include/purespice.h
+++ b/include/purespice.h
@@ -256,6 +256,22 @@ typedef struct PSConfig
 
     /* automatically connect to the channel as soon as it's available */
     bool autoConnect;
+
+    /* called to indicate the cursor image has changed to an RGBA bitmap
+     * with hotspot at (hx, hy) */
+    void (*setRGBAImage)(int width, int height, int hx, int hy,
+      const void * data);
+
+    /* called to indicate the cursor image has changed to an monochrome bitmap
+     * with hotspot at (hx, hy) */
+    void (*setMonoImage)(int width, int height, int hx, int hy,
+      const void * xorMask, const void * andMask);
+
+    /* called to indicate that the mouse position is set as follows */
+    void (*setState)(bool visible, int x, int y);
+
+    /* called to indicate that the mouse trail is set as follows (optional) */
+    void (*setTrail)(int length, int frequency);
   }
   cursor;
 }

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -197,6 +197,15 @@ static PS_STATUS onMessage_cursorMove(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorHide(PSChannel * channel)
+{
+  (void) channel;
+
+  g_ps.cursor.visible = false;
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -213,6 +222,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 
     case SPICE_MSG_CURSOR_MOVE:
       return onMessage_cursorMove;
+
+    case SPICE_MSG_CURSOR_HIDE:
+      return onMessage_cursorHide;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -216,6 +216,30 @@ static PS_STATUS onMessage_cursorTrail(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorInvalOne(PSChannel * channel)
+{
+  SpiceMsgCursorInvalOne * msg = (SpiceMsgCursorInvalOne *)channel->buffer;
+
+  struct PSCursorImage ** prev = &g_ps.cursor.cache;
+  struct PSCursorImage  * node = g_ps.cursor.cache;
+
+  while (node)
+  {
+    if (node->header.unique == msg->cursor_id)
+    {
+      *prev = node->next;
+      if (!node->next)
+        g_ps.cursor.cacheLast = prev;
+      break;
+    }
+
+    prev = &node->next;
+    node = node->next;
+  }
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -238,6 +262,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 
     case SPICE_MSG_CURSOR_TRAIL:
       return onMessage_cursorTrail;
+
+    case SPICE_MSG_CURSOR_INVAL_ONE:
+      return onMessage_cursorInvalOne;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -150,6 +150,27 @@ static PS_STATUS onMessage_cursorInit(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorReset(PSChannel * channel)
+{
+  (void) channel;
+
+  g_ps.cursor.visible = false;
+  g_ps.cursor.current = NULL;
+
+  struct PSCursorImage * node;
+  struct PSCursorImage * next;
+  for (node = g_ps.cursor.cache; node; node = next)
+  {
+    next = node->next;
+    free(node);
+  }
+
+  g_ps.cursor.cache     = NULL;
+  g_ps.cursor.cacheLast = NULL;
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -157,6 +178,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
   {
     case SPICE_MSG_CURSOR_INIT:
       return onMessage_cursorInit;
+
+    case SPICE_MSG_CURSOR_RESET:
+      return onMessage_cursorReset;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -1,0 +1,92 @@
+/*
+PureSpice - A pure C implementation of the SPICE client protocol
+Copyright (C) 2017-2022 Geoffrey McRae <geoff@hostfission.com>
+https://github.com/gnif/PureSpice
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "purespice.h"
+
+#include "ps.h"
+#include "log.h"
+#include "channel.h"
+#include "channel_cursor.h"
+
+#include <stdio.h>
+
+#include "messages.h"
+
+const SpiceLinkHeader * channelCursor_getConnectPacket(void)
+{
+  typedef struct
+  {
+    SpiceLinkHeader header;
+    SpiceLinkMess   message;
+    uint32_t        supportCaps[COMMON_CAPS_BYTES / sizeof(uint32_t)];
+    uint32_t        channelCaps[RECORD_CAPS_BYTES / sizeof(uint32_t)];
+  }
+  __attribute__((packed)) ConnectPacket;
+
+  static ConnectPacket p =
+  {
+    .header = {
+      .magic         = SPICE_MAGIC        ,
+      .major_version = SPICE_VERSION_MAJOR,
+      .minor_version = SPICE_VERSION_MINOR,
+      .size          = sizeof(ConnectPacket) - sizeof(SpiceLinkHeader)
+    },
+    .message = {
+      .channel_type     = SPICE_CHANNEL_CURSOR,
+      .num_common_caps  = COMMON_CAPS_BYTES / sizeof(uint32_t),
+      .num_channel_caps = CURSOR_CAPS_BYTES / sizeof(uint32_t),
+      .caps_offset      = sizeof(SpiceLinkMess)
+    }
+  };
+
+  p.message.connection_id = g_ps.sessionID;
+  p.message.channel_id    = g_ps.channelID;
+
+  memset(p.supportCaps, 0, sizeof(p.supportCaps));
+  memset(p.channelCaps, 0, sizeof(p.channelCaps));
+
+  COMMON_SET_CAPABILITY(p.supportCaps, SPICE_COMMON_CAP_PROTOCOL_AUTH_SELECTION);
+  COMMON_SET_CAPABILITY(p.supportCaps, SPICE_COMMON_CAP_AUTH_SPICE             );
+  COMMON_SET_CAPABILITY(p.supportCaps, SPICE_COMMON_CAP_MINI_HEADER            );
+
+  return &p.header;
+}
+
+static PS_STATUS onMessage_cursorInit(PSChannel * channel)
+{
+  SpiceMsgCursorInit * msg = (SpiceMsgCursorInit *)channel->buffer;
+
+  g_ps.cursor.x       = msg->position.x;
+  g_ps.cursor.y       = msg->position.y;
+  g_ps.cursor.visible = msg->visible;
+
+  return PS_STATUS_OK;
+}
+
+PSHandlerFn channelCursor_onMessage(PSChannel * channel)
+{
+  channel->initDone = true;
+  switch(channel->header.type)
+  {
+    case SPICE_MSG_CURSOR_INIT:
+      return onMessage_cursorInit;
+  }
+
+  return PS_HANDLER_DISCARD;
+}

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -171,6 +171,22 @@ static PS_STATUS onMessage_cursorReset(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorSet(PSChannel * channel)
+{
+  SpiceMsgCursorSet * msg = (SpiceMsgCursorSet *)channel->buffer;
+
+  g_ps.cursor.x       = msg->position.x;
+  g_ps.cursor.y       = msg->position.y;
+  g_ps.cursor.visible = msg->visible;
+
+  if (g_ps.cursor.current && !g_ps.cursor.current->cached)
+    free(g_ps.cursor.current);
+
+  g_ps.cursor.current = convertCursor(&msg->cursor);
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -181,6 +197,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 
     case SPICE_MSG_CURSOR_RESET:
       return onMessage_cursorReset;
+
+    case SPICE_MSG_CURSOR_SET:
+      return onMessage_cursorSet;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -206,6 +206,16 @@ static PS_STATUS onMessage_cursorHide(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorTrail(PSChannel * channel)
+{
+  SpiceMsgCursorTrail * msg = (SpiceMsgCursorTrail *)channel->buffer;
+
+  g_ps.cursor.trailLen  = msg->length;
+  g_ps.cursor.trailFreq = msg->frequency;
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -225,6 +235,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 
     case SPICE_MSG_CURSOR_HIDE:
       return onMessage_cursorHide;
+
+    case SPICE_MSG_CURSOR_TRAIL:
+      return onMessage_cursorTrail;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.c
+++ b/src/channel_cursor.c
@@ -187,6 +187,16 @@ static PS_STATUS onMessage_cursorSet(PSChannel * channel)
   return PS_STATUS_OK;
 }
 
+static PS_STATUS onMessage_cursorMove(PSChannel * channel)
+{
+  SpiceMsgCursorMove * msg = (SpiceMsgCursorMove *)channel->buffer;
+
+  g_ps.cursor.x = msg->position.x;
+  g_ps.cursor.y = msg->position.y;
+
+  return PS_STATUS_OK;
+}
+
 PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 {
   channel->initDone = true;
@@ -200,6 +210,9 @@ PSHandlerFn channelCursor_onMessage(PSChannel * channel)
 
     case SPICE_MSG_CURSOR_SET:
       return onMessage_cursorSet;
+
+    case SPICE_MSG_CURSOR_MOVE:
+      return onMessage_cursorMove;
   }
 
   return PS_HANDLER_DISCARD;

--- a/src/channel_cursor.h
+++ b/src/channel_cursor.h
@@ -1,0 +1,24 @@
+/*
+PureSpice - A pure C implementation of the SPICE client protocol
+Copyright (C) 2017-2020 Geoffrey McRae <geoff@hostfission.com>
+https://github.com/gnif/PureSpice
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "ps.h"
+
+const SpiceLinkHeader * channelCursor_getConnectPacket(void);
+
+PSHandlerFn channelCursor_onMessage(PSChannel * channel);

--- a/src/messages.h
+++ b/src/messages.h
@@ -257,6 +257,62 @@ typedef struct SpiceMsgDisplayDrawCopy
 }
 SpiceMsgDisplayDrawCopy;
 
+typedef struct SpiceCursorHeader
+{
+  uint64_t unique;
+  uint8_t type;
+  uint16_t width;
+  uint16_t height;
+  uint16_t hot_spot_x;
+  uint16_t hot_spot_y;
+}
+SpiceCursorHeader;
+
+typedef struct SpiceCursor
+{
+  uint16_t          flags;
+  SpiceCursorHeader header;
+  uint8_t           data[];
+}
+SpiceCursor;
+
+typedef struct SpiceMsgCursorInit
+{
+  SpicePoint16 position;
+  uint16_t     trail_length;
+  uint16_t     trail_frequency;
+  uint8_t      visible;
+  SpiceCursor  cursor;
+}
+SpiceMsgCursorInit;
+
+typedef struct SpiceMsgCursorSet
+{
+  SpicePoint16 position;
+  uint8_t      visible;
+  SpiceCursor  cursor;
+}
+SpiceMsgCursorSet;
+
+typedef struct SpiceMsgCursorMove
+{
+  SpicePoint16 position;
+}
+SpiceMsgCursorMove;
+
+typedef struct SpiceMsgCursorTrail
+{
+  uint16_t     length;
+  uint16_t     frequency;
+}
+SpiceMsgCursorTrail;
+
+typedef struct SpiceMsgCursorInvalOne
+{
+  uint64_t cursor_id;
+}
+SpiceMsgCursorInvalOne;
+
 // spice is missing these defines, the offical reference library incorrectly
 // uses the VD defines
 
@@ -283,6 +339,9 @@ SpiceMsgDisplayDrawCopy;
 
 #define DISPLAY_CAPS_BYTES (((SPICE_DISPLAY_CAP_CODEC_H265 + 32) / 8) & ~3)
 #define DISPLAY_SET_CAPABILITY(caps, index) _SET_CAPABILITY(caps, index)
+
+#define CURSOR_CAPS_BYTES (0)
+#define CUSROR_SET_CAPABILITY(caps, index) _SET_CAPABILITY(caps, index)
 
 #pragma pack(pop)
 

--- a/src/ps.c
+++ b/src/ps.c
@@ -28,6 +28,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "channel_playback.h"
 #include "channel_record.h"
 #include "channel_display.h"
+#include "channel_cursor.h"
 
 #include "messages.h"
 #include "rsa.h"
@@ -84,6 +85,7 @@ PS g_ps =
       .getConnectPacket = channelRecord_getConnectPacket,
       .onMessage        = channelRecord_onMessage,
     },
+    // PS_CHANNEL_DISPLAY
     {
       .spiceType        = SPICE_CHANNEL_DISPLAY,
       .name             = "DISPLAY",
@@ -92,6 +94,15 @@ PS g_ps =
       .getConnectPacket = channelDisplay_getConnectPacket,
       .onConnect        = channelDisplay_onConnect,
       .onMessage        = channelDisplay_onMessage
+    },
+    // PS_CHANNEL_CURSOR
+    {
+      .spiceType        = SPICE_CHANNEL_CURSOR,
+      .name             = "CURSOR",
+      .enable           = &g_ps.config.cursor.enable,
+      .autoConnect      = &g_ps.config.cursor.autoConnect,
+      .getConnectPacket = channelCursor_getConnectPacket,
+      .onMessage        = channelCursor_onMessage
     }
   }
 };
@@ -578,6 +589,9 @@ static uint8_t channelTypeToSpiceType(PSChannelType channel)
 
     case PS_CHANNEL_DISPLAY:
       return SPICE_CHANNEL_DISPLAY;
+
+    case PS_CHANNEL_CURSOR:
+      return SPICE_CHANNEL_CURSOR;
 
     default:
       PS_LOG_ERROR("Invalid channel");

--- a/src/ps.h
+++ b/src/ps.h
@@ -23,6 +23,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "purespice.h"
 
 #include "locking.h"
+#include "messages.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -154,6 +155,14 @@ struct PSChannel
   atomic_flag lock;
 };
 
+struct PSCursorImage
+{
+  struct PSCursorImage * next;
+  bool                   cached;
+  SpiceCursorHeader      header;
+  uint8_t                buffer[];
+};
+
 struct PS
 {
   bool     initialized;
@@ -195,6 +204,17 @@ struct PS
     int rpos, wpos;
   }
   mouse;
+
+  struct
+  {
+    uint16_t                x, y;
+    uint16_t                trailLen, trailFreq;
+    bool                    visible;
+    struct PSCursorImage  * cache;
+    struct PSCursorImage ** cacheLast;
+    struct PSCursorImage  * current;
+  }
+  cursor;
 
   uint8_t * motionBuffer;
   size_t    motionBufferSize;


### PR DESCRIPTION
This PR implements the Spice cursor channel.

In the future, when non-RGBA non-monochrome formats are added, PureSpice should decode them to RGBA.