### PR TITLE
Remove non-prototype function declarations

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -510,7 +510,7 @@ bool purespice_clipboardGrab(PSDataType types[], int count)
   return true;
 }
 
-bool purespice_clipboardRelease()
+bool purespice_clipboardRelease(void)
 {
   if (!agent.present)
     return false;

--- a/src/ps.c
+++ b/src/ps.c
@@ -284,7 +284,7 @@ err_host:
   return false;
 }
 
-void purespice_disconnect()
+void purespice_disconnect(void)
 {
   if (!g_ps.initialized)
   {


### PR DESCRIPTION
With -Wstrict-prototypes on non-protyped functions are deprecated and functions must include a void parameter if it does not take parameters.

Closes #18