### PR TITLE
rsa: add compatibility for nettle 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ pkg_check_modules(SPICE_PKGCONFIG REQUIRED
 	hogweed
 )
 
+if (SPICE_PKGCONFIG_nettle_VERSION)
+	if (SPICE_PKGCONFIG_nettle_VERSION VERSION_GREATER_EQUAL "4.0")
+		message(STATUS "Using nettle >= 4.0 compatibility")
+		add_compile_definitions(USE_NETTLE_GE_4)
+	endif()
+endif()
+
 add_definitions(-D USE_NETTLE)
 
 add_compile_options(

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -62,7 +62,12 @@ static void sha1(uint8_t * hash, const uint8_t *data, unsigned int len)
 
   sha1_init(&ctx);
   sha1_update(&ctx, len, data);
+
+#if defined(USE_NETTLE_GE_4)
+  sha1_digest(&ctx, hash);
+#else
   sha1_digest(&ctx, SHA1_HASH_LEN, hash);
+#endif
 }
 
 static void oaep_mask(uint8_t * dest, size_t dest_len,


### PR DESCRIPTION
This PR adds version detection for nettle 4.x in cmake and updates the call to `sha1_digest` in nettle to be compatible with the new signature if using nettle >= 4.

This resolves #21 and once merged, the dependency in LG can also be updated to deal with https://github.com/gnif/LookingGlass/issues/1269